### PR TITLE
Default boost_python to libraries if not found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,20 +8,25 @@ include_dirs = ["/usr/local/include", "/opt/local/include"]
 library_dirs = ["/usr/lib", "/usr/lib64", "/usr/local/lib", "/usr/local/lib64", "/opt/local/lib"]
 libraries = ["config++"]
 
-# lookup library TODO: is there some API for this?
-#for d in library_dirs:
-#    libs = glob(join(d, "libboost_python.so"))
-#    if not(libs):
-#        libs = glob(join(d, "libboost_python*.so"))
-#    if libs:
-#        libname = basename(libs[0])         # basename
-#        libname = splitext(libname)[0]      # truncate postfix
-#        libname = libname[3:]               # truncate "lib"
-#        libraries.append(libname)
-#        break
+# Attempt to find libboost_python.so or some variant by searching through the
+# library directories.
+# TODO: is there some API for this?
+for d in library_dirs:
+    libs = glob(join(d, "libboost_python.so"))
+    if not(libs):
+        libs = glob(join(d, "libboost_python*.so"))
+    if libs:
+        libname = basename(libs[0])         # basename
+        libname = splitext(libname)[0]      # truncate postfix
+        libname = libname[3:]               # truncate "lib"
+        libraries.append(libname)
+        break
 
-# check that we really found boost
-#assert(len(libraries) > 1)
+# If we were unable to find the shared library go ahead in a default. It might
+# be in an unofficial directory and an environment variable has been set that
+# will point the compiler to it.
+if len(libraries) <= 1:
+    libraries.append('boost_python')
 
 setup(
     name='pylibconfig',


### PR DESCRIPTION
Searching a specific set of directories for a library is prone to error. For example, when I build python-libconfig I use `CFLAGS` and other compiler environment variables to point to a custom build of Boost.

Rather than `assert` if the search fails this patch simply adds in `boost_python` to the libraries and let's the compiler resolve it if it can.
